### PR TITLE
added possibility to cache Autoloader with APC or XCache

### DIFF
--- a/web/app.php
+++ b/web/app.php
@@ -1,11 +1,23 @@
 <?php
 
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\ClassLoader\ApcClassLoader;
+use Symfony\Component\ClassLoader\XcacheClassLoader;
 
 $loader = require_once __DIR__.'/../app/bootstrap.php.cache';
 
 require_once __DIR__.'/../app/AppKernel.php';
 require_once __DIR__.'/../app/AppCache.php';
+
+if (extension_loaded('apc') && ini_get('apc.enabled')) {
+    $loader = new ApcClassLoader('superdesk_webpublisher', $loader);
+    $loader->register(true);
+}
+
+if (extension_loaded('xcache') && ini_get('xcache.enabled')) {
+    $loader = new XcacheClassLoader('superdesk_webpublisher', $loader);
+    $loader->register(true);
+}
 
 $kernel = new AppKernel('prod', false);
 $kernel->loadClassCache();


### PR DESCRIPTION
See the performance improvements with APC (APCu) enabled, on each request.

![q39jkhtr-lkxrwnkqa8j-t9rlc7yihgf_pyhs5-qe14](https://cloud.githubusercontent.com/assets/562536/10543665/8fb3165e-741f-11e5-92e9-6f49b6aa1187.png)

This can be achived also, by running command:

```bash
composer dump-autoload --optimize
```

but also there should be the possibility to cache Autoloader automatically when apc or xcache is enabled for better performance.

See http://symfony.com/doc/current/book/performance.html as a reference.

