### PR TITLE
add composer exclude-from-classmap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,10 @@
     "autoload": {
         "psr-4": {
             "": "src/"
-        }
+        },
+        "exclude-from-classmap": [
+            "**/Tests/", "**/spec/"
+        ]
     },
     "require": {
         "php": ">=5.5",


### PR DESCRIPTION
excludes not needed tests/specs files from classmap, useful in prod env as we don't need there tests

I would suggest to add this option to every bundle/component we created.